### PR TITLE
Remove unused "platform-version" property from org.csstudio:product POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,6 @@
 				<eclipse-update-site>http://download.eclipse.org/eclipse/updates/4.4</eclipse-update-site>
 				<rap-site>http://download.eclipse.org/rt/rap/2.3</rap-site>
 				<rap-incubator-site>http://download.eclipse.org/rt/rap/incubator/nightly/gef</rap-incubator-site>
-				<platform-version>[4.3,4.4)</platform-version>
 				<swtbot-site>http://download.eclipse.org/technology/swtbot/luna/dev-build/update-site</swtbot-site>
 			</properties>
 		</profile>
@@ -93,7 +92,6 @@
 				<eclipse-update-site>http://download.eclipse.org/eclipse/updates/4.4</eclipse-update-site>
 				<rap-site>http://download.eclipse.org/rt/rap/2.3</rap-site>
 				<rap-incubator-site>http://download.eclipse.org/rt/rap/incubator/nightly/gef</rap-incubator-site>
-				<platform-version>[4.3,4.4)</platform-version>
 				<swtbot-site>http://download.eclipse.org/technology/swtbot/luna/dev-build/update-site</swtbot-site>
 			</properties>
 		</profile>
@@ -110,7 +108,6 @@
 				<eclipse-update-site>http://download.eclipse.org/eclipse/updates/4.3</eclipse-update-site>
 				<rap-site>http://download.eclipse.org/rt/rap/2.2</rap-site>
 				<rap-incubator-site>http://download.eclipse.org/rt/rap/incubator/2.2/gef</rap-incubator-site>
-				<platform-version>[4.2,4.3)</platform-version>
 				<swtbot-site>http://download.eclipse.org/technology/swtbot/kepler/dev-build/update-site</swtbot-site>
 			</properties>
 		</profile>


### PR DESCRIPTION
This is the same change as [`cs-studio` #785](https://github.com/ControlSystemStudio/cs-studio/pull/785).