### PR TITLE
#799 updating the common product 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@
 		</repository>
 		<repository>
 			<id>efx</id>
-			<url>http://download.eclipse.org/efxclipse/runtime-nightly/site</url>
+			<url>http://download.eclipse.org/efxclipse/runtime-released/1.2.0/site</url>
 			<layout>p2</layout>
 		</repository>
 	</repositories>

--- a/repository/cs-studio.product
+++ b/repository/cs-studio.product
@@ -21,6 +21,8 @@
 -Dosgi.sharedConfiguration.area.readOnly=true
 -Dosgi.install.area.readOnly=true
 -Dosgi.requiredJavaVersion=1.8
+-Dorg.osgi.framework.bundle.parent=ext 
+-Dosgi.framework.extensions=org.eclipse.fx.osgi
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
@@ -78,6 +80,7 @@
       <feature id="org.csstudio.pvmanager.autocomplete.feature"/>
       <feature id="org.csstudio.opibuilder.feature"/>
       <feature id="org.csstudio.product.configuration.feature"/>
+      <feature id="org.eclipse.fx.target.feature"/>
    </features>
 
    <configurations>


### PR DESCRIPTION
-using a released verison of e(fx)clipse instead of the nightly releases
-included the required features in the products to ensure that logging.ui works with the javafxviews
-including the appropriate vmargs to ensure the javafx works for the logging.ui plugin by

https://github.com/ControlSystemStudio/cs-studio/issues/799

Merge instructions:
build should work
common product should have the loggingConfiguration view operational